### PR TITLE
Patch -  New version

### DIFF
--- a/coverage.out
+++ b/coverage.out
@@ -1,0 +1,11 @@
+mode: count
+github.com/LNMMusic/optional/bson_encoder.go:9.82,16.2 3 4
+github.com/LNMMusic/optional/bson_encoder.go:19.81,23.2 2 3
+github.com/LNMMusic/optional/json_encoder.go:13.60,16.2 2 32
+github.com/LNMMusic/optional/json_encoder.go:27.59,30.2 2 24
+github.com/LNMMusic/optional/optional.go:13.37,15.2 1 47
+github.com/LNMMusic/optional/optional.go:17.30,19.2 1 30
+github.com/LNMMusic/optional/optional.go:31.35,33.2 1 41
+github.com/LNMMusic/optional/optional.go:36.36,37.20 1 34
+github.com/LNMMusic/optional/optional.go:37.20,38.33 1 9
+github.com/LNMMusic/optional/optional.go:40.2,41.8 2 25

--- a/json_encoder_test.go
+++ b/json_encoder_test.go
@@ -21,9 +21,7 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.True(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, "hello", v)
+		require.Equal(t, "hello", option.Unwrap())
 	})
 	t.Run("JSON - string null", func(t *testing.T) {
 		// arrange
@@ -36,10 +34,6 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.False(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.Equal(t, "", v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
 	})
 
 	// int
@@ -54,9 +48,7 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.True(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, 1, v)
+		require.Equal(t, 1, option.Unwrap())
 	})
 	t.Run("JSON - int null", func(t *testing.T) {
 		// arrange
@@ -69,10 +61,6 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.False(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.Equal(t, 0, v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
 	})
 
 	// float64
@@ -87,9 +75,7 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.True(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, 1.0, v)
+		require.Equal(t, 1.0, option.Unwrap())
 	})
 	t.Run("JSON - float64 null", func(t *testing.T) {
 		// arrange
@@ -102,10 +88,6 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.False(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.Equal(t, 0.0, v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
 	})
 
 	// bool
@@ -120,9 +102,7 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.True(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, true, v)
+		require.Equal(t, true, option.Unwrap())
 	})
 	t.Run("JSON - bool null", func(t *testing.T) {
 		// arrange
@@ -135,10 +115,6 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.False(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.Equal(t, false, v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
 	})
 
 	// []string
@@ -153,9 +129,7 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.True(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, []string{"hello", "world"}, v)
+		require.Equal(t, []string{"hello", "world"}, option.Unwrap())
 	})
 	t.Run("JSON - []string null", func(t *testing.T) {
 		// arrange
@@ -168,10 +142,6 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.False(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.Equal(t, []string(nil), v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
 	})
 
 	// []int
@@ -186,9 +156,7 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.True(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, []int{1, 2, 3}, v)
+		require.Equal(t, []int{1, 2, 3}, option.Unwrap())
 	})
 	t.Run("JSON - []int null", func(t *testing.T) {
 		// arrange
@@ -201,10 +169,6 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.False(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.Equal(t, []int(nil), v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
 	})
 
 	// []float64
@@ -219,9 +183,7 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.True(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, []float64{1.0, 2.0, 3.0}, v)
+		require.Equal(t, []float64{1.0, 2.0, 3.0}, option.Unwrap())
 	})
 	t.Run("JSON - []float64 null", func(t *testing.T) {
 		// arrange
@@ -234,10 +196,6 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.False(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.Equal(t, []float64(nil), v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
 	})
 
 	// []bool
@@ -252,9 +210,7 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.True(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, []bool{true, false}, v)
+		require.Equal(t, []bool{true, false}, option.Unwrap())
 	})
 	t.Run("JSON - []bool null", func(t *testing.T) {
 		// arrange
@@ -267,10 +223,6 @@ func TestOption_Unmarshal(t *testing.T) {
 		// assert
 		require.NoError(t, err)
 		require.False(t, option.IsSome())
-		v, err := option.Unwrap()
-		require.Equal(t, []bool(nil), v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
 	})
 
 	// structered data (all types)
@@ -366,14 +318,14 @@ func TestOption_Unmarshal(t *testing.T) {
 
 		// assert
 		require.NoError(t, err)
-		require.True(t, ts.FirstName.IsSome()); v1, err1 := ts.FirstName.Unwrap(); require.NoError(t, err1); require.Equal(t, "Mary", v1)
-		require.True(t, ts.Age.IsSome()); v2, err2 := ts.Age.Unwrap(); require.NoError(t, err2); require.Equal(t, 20, v2)
-		require.True(t, ts.Height.IsSome()); v3, err3 := ts.Height.Unwrap(); require.NoError(t, err3); require.Equal(t, 1.7, v3)
-		require.True(t, ts.Licensed.IsSome()); v4, err4 := ts.Licensed.Unwrap(); require.NoError(t, err4); require.Equal(t, true, v4)
-		require.True(t, ts.Pets.IsSome()); v5, err5 := ts.Pets.Unwrap(); require.NoError(t, err5); require.Equal(t, []string{"dog", "cat"}, v5)
-		require.True(t, ts.Numbers.IsSome()); v6, err6 := ts.Numbers.Unwrap(); require.NoError(t, err6); require.Equal(t, []int{1, 2, 3}, v6)
-		require.True(t, ts.Location.IsSome()); v7, err7 := ts.Location.Unwrap(); require.NoError(t, err7); require.Equal(t, []float64{1.0, 2.0, 3.0}, v7)
-		require.True(t, ts.Bools.IsSome()); v8, err8 := ts.Bools.Unwrap(); require.NoError(t, err8); require.Equal(t, []bool{true, false}, v8)
+		require.True(t, ts.FirstName.IsSome()); require.Equal(t, "Mary", ts.FirstName.Unwrap())
+		require.True(t, ts.Age.IsSome()); require.Equal(t, 20, ts.Age.Unwrap())
+		require.True(t, ts.Height.IsSome()); require.Equal(t, 1.7, ts.Height.Unwrap())
+		require.True(t, ts.Licensed.IsSome()); require.Equal(t, true, ts.Licensed.Unwrap())
+		require.True(t, ts.Pets.IsSome()); require.Equal(t, []string{"dog", "cat"}, ts.Pets.Unwrap())
+		require.True(t, ts.Numbers.IsSome()); require.Equal(t, []int{1, 2, 3}, ts.Numbers.Unwrap())
+		require.True(t, ts.Location.IsSome()); require.Equal(t, []float64{1.0, 2.0, 3.0}, ts.Location.Unwrap())
+		require.True(t, ts.Bools.IsSome()); require.Equal(t, []bool{true, false}, ts.Bools.Unwrap())
 	})
 }
 

--- a/optional.go
+++ b/optional.go
@@ -32,10 +32,10 @@ func (o *Option[T]) IsSome() bool {
 	return o.value != nil
 }
 // Unwrap returns a copy of the inner value of a Some.
-func (o *Option[T]) Unwrap() (t T, err error) {
+// If the Option is a None, Unwrap panics.
+func (o *Option[T]) Unwrap() (t T) {
 	if o.value == nil {
-		err = ErrUnwrapNone
-		return
+		panic("unable to unwrap None")
 	}
 	t = *o.value
 	return

--- a/optional_test.go
+++ b/optional_test.go
@@ -10,149 +10,176 @@ import (
 func TestOption_Some(t *testing.T) {
 	t.Run("Some - string", func(t *testing.T) {
 		// arrange
-		var input string = "hello"
-		var output = Option[string]{value: &input}
-
+		// ...
+		
 		// act
+		input := "hello"
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[string]{value: new(string)}; *expected.value = "hello"
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := "hello"
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 
 	t.Run("Some - int", func(t *testing.T) {
 		// arrange
-		var input int = 1
-		var output = Option[int]{value: &input}
-
+		// ...
+		
 		// act
+		input := 42
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[int]{value: new(int)}; *expected.value = 42
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := 42
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 
 	t.Run("Some - float64", func(t *testing.T) {
 		// arrange
-		var input float64 = 1.0
-		var output = Option[float64]{value: &input}
-
+		// ...
+		
 		// act
+		input := 42.0
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[float64]{value: new(float64)}; *expected.value = 42.0
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := 42.0
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 
 	t.Run("Some - bool", func(t *testing.T) {
 		// arrange
-		var input bool = true
-		var output = Option[bool]{value: &input}
-
+		// ...
+		
 		// act
+		input := true
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[bool]{value: new(bool)}; *expected.value = true
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := true
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 
 	t.Run("Some - []string", func(t *testing.T) {
 		// arrange
-		var input []string = []string{"hello", "world"}
-		var output = Option[[]string]{value: &input}
+		// ...
 
 		// act
+		input := []string{"hello", "world"}
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[[]string]{value: new([]string)}; *expected.value = []string{"hello", "world"}
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := []string{"hello", "world"}
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 
 	t.Run("Some - []int", func(t *testing.T) {
 		// arrange
-		var input []int = []int{1, 2, 3}
-		var output = Option[[]int]{value: &input}
+		// ...
 
 		// act
+		input := []int{42, 42}
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[[]int]{value: new([]int)}; *expected.value = []int{42, 42}
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := []int{42, 42}
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 
 	t.Run("Some - []float64", func(t *testing.T) {
 		// arrange
-		var input []float64 = []float64{1.0, 2.0, 3.0}
-		var output = Option[[]float64]{value: &input}
+		// ...
 
 		// act
+		input := []float64{42.0, 42.0}
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[[]float64]{value: new([]float64)}; *expected.value = []float64{42.0, 42.0}
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := []float64{42.0, 42.0}
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 
 	t.Run("Some - []bool", func(t *testing.T) {
 		// arrange
-		var input []bool = []bool{true, false}
-		var output = Option[[]bool]{value: &input}
+		// ...
 
 		// act
+		input := []bool{true, true}
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[[]bool]{value: new([]bool)}; *expected.value = []bool{true, true}
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := []bool{true, true}
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 
 	t.Run("Some - struct", func(t *testing.T) {
 		// arrange
 		type testStruct struct {
-			value string
+			a int
+			b string
 		}
-		var input testStruct = testStruct{value: "hello"}
-		var output = Option[testStruct]{value: &input}
-
+		
 		// act
+		input := testStruct{a: 42, b: "hello"}
 		result := Some(input)
 
 		// assert
-		require.Equal(t, output, result)
+		// - optional equality
+		expected := Option[testStruct]{value: new(testStruct)}; *expected.value = testStruct{a: 42, b: "hello"}
+		require.Equal(t, expected, result)
+		// - check if it is a Some
 		require.True(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.NoError(t, err)
-		require.Equal(t, input, v)
+		// - check unwrapped value
+		expectedUnwrap := testStruct{a: 42, b: "hello"}
+		require.Equal(t, expectedUnwrap, result.Unwrap())
 	})
 }
 
@@ -160,146 +187,163 @@ func TestOption_Some(t *testing.T) {
 func TestOption_None(t *testing.T) {
 	t.Run("None - string", func(t *testing.T) {
 		// arrange
-		var output = Option[string]{value: nil}
+		// ...
 
 		// act
 		result := None[string]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, "", v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v string
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, "", v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 
 	t.Run("None - int", func(t *testing.T) {
 		// arrange
-		var output = Option[int]{value: nil}
+		// ...
 
 		// act
 		result := None[int]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, 0, v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v int
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, 0, v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 
 	t.Run("None - float64", func(t *testing.T) {
 		// arrange
-		var output = Option[float64]{value: nil}
+		// ...
 
 		// act
 		result := None[float64]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, 0.0, v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v float64
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, 0.0, v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 
 	t.Run("None - bool", func(t *testing.T) {
 		// arrange
-		var output = Option[bool]{value: nil}
+		// ...
 
 		// act
 		result := None[bool]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, false, v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v bool
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, false, v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 
 	t.Run("None - []string", func(t *testing.T) {
 		// arrange
-		var output = Option[[]string]{value: nil}
+		// ...
 
 		// act
 		result := None[[]string]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, []string(nil), v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v []string
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, []string(nil), v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 
 	t.Run("None - []int", func(t *testing.T) {
 		// arrange
-		var output = Option[[]int]{value: nil}
+		// ...
 
 		// act
 		result := None[[]int]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, []int(nil), v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v []int
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, []int(nil), v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 
 	t.Run("None - []float64", func(t *testing.T) {
 		// arrange
-		var output = Option[[]float64]{value: nil}
+		// ...
 
 		// act
 		result := None[[]float64]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, []float64(nil), v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v []float64
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, []float64(nil), v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 
 	t.Run("None - []bool", func(t *testing.T) {
 		// arrange
-		var output = Option[[]bool]{value: nil}
+		// ...
 
 		// act
 		result := None[[]bool]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, []bool(nil), v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v []bool
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, []bool(nil), v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 
 	t.Run("None - struct", func(t *testing.T) {
 		// arrange
 		type testStruct struct {}
-		var output = Option[testStruct]{value: nil}
 
 		// act
 		result := None[testStruct]()
 
 		// assert
-		require.Equal(t, output, result)
-		require.False(t, result.IsSome())
-		v, err := result.Unwrap()
-		require.Equal(t, testStruct{}, v)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrUnwrapNone)
+		var v testStruct
+		defer func() {
+			if r := recover(); r != nil {
+				require.Equal(t, testStruct{}, v)
+				require.Equal(t, "unable to unwrap None", r)
+			}
+		}()
+		v = result.Unwrap()
 	})
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Optional
 
-The `optional` package is a Golang package that provides a type called `Option` for representing optional values. It allows you to handle scenarios where a value may or may not be present.
+The `optional` package is a Golang package that provides a type called `Option` for representing optional values. It allows you to handle scenarios where a value may or may not be present. This include compatibility with dynamic types such as maps and JSON where the existence of a key may not be guaranteed. In this case the `Option` type can be used to represent the existence of a key and its value.
 
 ## Installation
 
@@ -28,7 +28,7 @@ The `Some` function creates an optional value with a non-nil inner value.
 
 ```go
 value := 42
-opt := optional.Some(value)
+opt := optional.Some[int](value)
 ```
 
 #### None
@@ -36,7 +36,7 @@ opt := optional.Some(value)
 The `None` function creates an optional value with a nil inner value.
 
 ```go
-opt := optional.None()
+opt := optional.None[int]()
 ```
 
 ### Checking if an Optional Value is Some
@@ -53,14 +53,14 @@ if opt.IsSome() {
 
 ### Unwrapping an Optional Value
 
-To retrieve the inner value of a `Some` optional value, you can use the `Unwrap` method. It returns the inner value and an error if the optional value is `None`.
+To retrieve the inner value of a `Some` optional value, you can use the `Unwrap` method. It returns the inner value. If the optional value is `None`, the function panics. You should handle this appropriately in your code.
 
 ```go
-value, err := opt.Unwrap()
-if err != nil {
-    // Handle the error
+if opt.IsSome() {
+	value := opt.Unwrap()
+	// Do something with the value
 } else {
-    // Use the inner value
+	// The optional value is None
 }
 ```
 
@@ -74,18 +74,14 @@ package main
 import (
 	"fmt"
 
-	"github.com/your-username/optional"
+	"github.com/LNMMusic/optional"
 )
 
 func main() {
-	opt := optional.Some(42)
+	opt := optional.Some[int](42)
 	if opt.IsSome() {
-		value, err := opt.Unwrap()
-		if err != nil {
-			fmt.Println("Error:", err)
-		} else {
-			fmt.Println("Value:", value)
-		}
+		value := opt.Unwrap()
+		fmt.Printf("The optional value is Some and its value is %d\n", value)
 	} else {
 		fmt.Println("The optional value is None")
 	}
@@ -94,7 +90,16 @@ func main() {
 
 ## Error Handling
 
-If you attempt to call the `Unwrap` method on a `None` optional value, it will return the `ErrUnwrapNone` error. You should handle this error appropriately in your code.
+If you attempt to call the `Unwrap` method on a `None` optional value, it will panic. You should handle this error appropriately in your code, by first checking if the optional value is `Some` or `None`.
+
+```go
+if opt.IsSome() {
+	value := opt.Unwrap()
+	// Do something with the value
+} else {
+	// The optional value is None
+}
+```
 
 ## JSON Marshalling and Unmarshalling
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Optional
 
-The `optional` package is a Golang package that provides a type called `Option` for representing optional values. It allows you to handle scenarios where a value may or may not be present. This include compatibility with dynamic types such as maps and JSON where the existence of a key may not be guaranteed. In this case the `Option` type can be used to represent the existence of a key and its value.
+The `optional` package is a Golang package that provides a type called `Option` for representing optional values. It allows you to handle `scenarios` where a `value` `may or may not be present`. This include compatibility with dynamic types such as maps and JSON where the `existence of a key` may not be guaranteed. In this case the `Option` type can be used to represent the existence of a key and its value.
 
 ## Installation
 
@@ -138,6 +138,13 @@ if err != nil {
 The output of the above code is `42` due to encodes straight forward the inner value of the optional
 
 Please note that marshalling a `None` optional value will result in `null` in the JSON output.
+
+#### *Rules*
+- If json is `null`, the optional value will be `None`. This means that optional DOES NOT DISTINGUISH between the `absence of the key` and the `presence of the key with a null value`. All `null` values are treated as `non-existent-values`. To avoid this, later will be available a new type called `Nullable` that will be able to extend the values on go with the `null` value. This can be combined with the `optional` type to create a `NullableOptional` type that will be able to distinguish between the `absence of the key` and the `presence of the key with a null value`.
+
+```go
+var optionalNullable := optional.Some[Nullable[int]](Nullable[int]{Value: nil})
+```
 
 ## License
 


### PR DESCRIPTION
Updates:
Redefine the main usage of optional as a type to check the existence or absence of a key
Unwrap now does not return an error, rather panic in case of None value
JSON Decoding / Encoding: null values are treated as non-existing-values, later a new type Nullable might be uploaded to be composed with the type Optional, to create an OptionalNullable fully compatible with dynamic types such as maps and json